### PR TITLE
Fix to allow templates to work even if interpolated property is undefined

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -38,8 +38,8 @@
 		for (m=0,l=arr.length; m < l; m++) {
 			str += arr[m].charAt(0) !== '\x1b' ?
 			"out+='" + arr[m].replace(/(\\|["'])/g, '\\$1') + "'" : (arr[m].charAt(1) === '=' ?
-			';out+=(' + arr[m].substr(2) + ');' : (arr[m].charAt(1) === '!' ?
-			';out+=(' + arr[m].substr(2) + ").toString().replace(/&(?!\\w+;)/g, '&#38;').split('<').join('&#60;').split('>').join('&#62;').split('" + '"' + "').join('&#34;').split(" + '"' + "'" + '"' + ").join('&#39;').split('/').join('&#x2F;');" : ';' + arr[m].substr(1)));
+			';out+=(' + arr[m].substr(2) + '||"");' : (arr[m].charAt(1) === '!' ?
+			';out+=(' + arr[m].substr(2) + "||'').toString().replace(/&(?!\\w+;)/g, '&#38;').split('<').join('&#60;').split('>').join('&#62;').split('" + '"' + "').join('&#34;').split(" + '"' + "'" + '"' + ").join('&#39;').split('/').join('&#x2F;');" : ';' + arr[m].substr(1)));
 		}
 
 		str = ('var out="";'+str+';return out;')


### PR DESCRIPTION
Fix to prevent template from blowing up on evaluation of undefined properties. This fix does a logical or to allow templates like this to pass:

```
{{ someObject = {} }}
{{! someObject.someProperty }}
```

I'm not sure if this is the best way to support this, but in my project, I sometimes access properties that may or may not be there and would prefer not to have to do this for each property I want to show:

```
{{! someObject.someProperty || "" }}
```
