### PR TITLE
Initial support for partials rendering

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -8,55 +8,47 @@
 //
 // Licensed under the MIT license.
 //
-(function() {
-	var doT = { version : '0.1.3' };
-
-	if (typeof module !== 'undefined' && module.exports) {
-		module.exports = doT;
-	} else {
-		this.doT = doT;
+(function () {
+  var doT = {
+    version: '0.1.3'
+  };
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = doT;
+  } else {
+    this.doT = doT;
+  }
+  doT.templateSettings = {
+    evaluate: /\{\{([\s\S]+?)\}\}/g,
+    interpolate: /\{\{=([\s\S]+?)\}\}/g,
+    expand :  /\{\{>([\s\S]+?)\}\}/g,
+    encode: /\{\{!([\s\S]+?)\}\}/g,
+    defines: /\{\{#([\s\S]+?)\}\}/g,
+    varname: 'it',
+    strip: true
+  };
+  doT.template = function (tmpl, c, defs) {
+    c = c || doT.templateSettings;
+    
+    while (tmpl.match(c.expand)) {
+        tmpl =  tmpl.replace(c.expand, function(match, code) { 
+	       return defs[code.replace(/ /g, '')];
+	    });
 	}
-
-	doT.templateSettings = {
-		evaluate : /\{\{([\s\S]+?)\}\}/g,
-		interpolate : /\{\{=([\s\S]+?)\}\}/g,
-		encode :  /\{\{!([\s\S]+?)\}\}/g,
-		defines:  /\{\{#([\s\S]+?)\}\}/g,
-		varname : 'it',
-		strip : true
-	};
-
-	doT.template = function(tmpl, c, defs) {
-		c = c || doT.templateSettings;
-		var str = ("var out='" +
-				((c.strip) ? tmpl.replace(/\s*<!\[CDATA\[\s*|\s*\]\]>\s*|[\r\n\t]|(\/\*[\s\S]*?\*\/)/g, ''):
-							 tmpl)
-				.replace(c.defines, function(match, code) {
-					return eval(code.replace(/[\r\t\n]/g, ' '));
-				})
-				.replace(/\\/g, '\\\\')
-				.replace(/'/g, "\\'")
-				.replace(c.interpolate, function(match, code) {
-					return "';out+=" + code.replace(/\\'/g, "'").replace(/\\\\/g,"\\").replace(/[\r\t\n]/g, ' ') + ";out+='";
-				})
-				.replace(c.encode, function(match, code) {
-					return "';out+=(" + code.replace(/\\'/g, "'").replace(/\\\\/g, "\\").replace(/[\r\t\n]/g, ' ') + ").toString().replace(/&(?!\\w+;)/g, '&#38;').split('<').join('&#60;').split('>').join('&#62;').split('" + '"' + "').join('&#34;').split(" + '"' + "'" + '"' + ").join('&#39;').split('/').join('&#x2F;');out+='";
-				})
-				.replace(c.evaluate, function(match, code) {
-					return "';" + code.replace(/\\'/g, "'").replace(/\\\\/g,"\\").replace(/[\r\t\n]/g, ' ') + "out+='";
-				})
-				+ "';return out;")
-				.replace(/\n/g, '\\n')
-				.replace(/\t/g, '\\t')
-				.replace(/\r/g, '\\r')
-				.split("out+='';").join('')
-				.split('var out="";out+=').join('var out=');
-
-		try {
-			return new Function(c.varname, str);
-		} catch (e) {
-			if (typeof console !== 'undefined') console.log("Could not create a template function: " + str);
-			throw e;
-		}
-	};
+    
+    var str = ("var out='" + ((c.strip) ? tmpl.replace(/\s*<!\[CDATA\[\s*|\s*\]\]>\s*|[\r\n\t]|(\/\*[\s\S]*?\*\/)/g, '') : tmpl).replace(c.defines, function (match, code) {
+      return eval(code.replace(/[\r\t\n]/g, ' '));
+    }).replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(c.interpolate, function (match, code) {
+      return "';out+=" + code.replace(/\\'/g, "'").replace(/\\\\/g, "\\").replace(/[\r\t\n]/g, ' ') + ";out+='";
+    }).replace(c.encode, function (match, code) {
+      return "';out+=(" + code.replace(/\\'/g, "'").replace(/\\\\/g, "\\").replace(/[\r\t\n]/g, ' ') + ").toString().replace(/&(?!\\w+;)/g, '&#38;').split('<').join('&#60;').split('>').join('&#62;').split('" + '"' + "').join('&#34;').split(" + '"' + "'" + '"' + ").join('&#39;').split('/').join('&#x2F;');out+='";
+    }).replace(c.evaluate, function (match, code) {
+      return "';" + code.replace(/\\'/g, "'").replace(/\\\\/g, "\\").replace(/[\r\t\n]/g, ' ') + "out+='";
+    }) + "';return out;").replace(/\n/g, '\\n').replace(/\t/g, '\\t').replace(/\r/g, '\\r').split("out+='';").join('').split('var out="";out+=').join('var out=');
+    try {
+      return new Function(c.varname, str);
+    } catch (e) {
+      if (typeof console !== 'undefined') console.log("Could not create a template function: " + str);
+      throw e;
+    }
+  };
 }());


### PR DESCRIPTION
Hello,

I've added an initial support for rendering template partials, based on mustache partial interpolation with `{{>partial_name}}``

``` js

var template = 'Hello {{=it.name}}, you are {{=it.details.age}} years old! {{> menu }}';

var partials = {
    menu : "<p>Hello again {{= it.name}} I still believe you are {{= it.details.age}} right? {{> banner}}</p>",
    banner : "Hey its me! Banner"
};

var data  = {
    name: 'John', 
    details : {age : 27}
};


doT.template(template, null, partials)(data)

//outputs
/*
    Hello John, you are 27 years old! 
    Hello again John I still believe you are 27 right? Hey its me! Banner
*/

```

As you can see the `partials` declaration is being passed in the same time as the template, not data, this is because I believe partials are directly related with the template itself since they can also be classified as `sub-templates`. It is being passed as the 3rd `defs` attribute now only because this one  wasn't being used before. The 3rd attribute could also be passed as an object witch contains the `defl` definition and another one for partials like `{defl : ..., partials : { ... })`

I hope this make sense :)

The while loop existis because it will expand the whole template and partials inside partials and then continue with the process.

I am really not an expert on performance, and I wouldn't like break the beauty of your engine which is performance/speed, so please let me know if this doesn't work the way it should.

Thanks
