### PR TITLE
Statements in tamplates

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -67,7 +67,7 @@
 				return cstart + code.replace(/\\'/g, "'").replace(/\\\\/g, "\\").replace(/[\r\t\n]/g, ' ') + ").toString().replace(/&(?!\\w+;)/g, '&#38;').split('<').join('&#60;').split('>').join('&#62;').split('" + '"' + "').join('&#34;').split(" + '"' + "'" + '"' + ").join('&#39;').split('/').join('&#47;'" + cend;
 			})
 			.replace(c.evaluate, function(match, code) {
-				return "';" + code.replace(/\\'/g, "'").replace(/\\\\/g,"\\").replace(/[\r\t\n]/g, ' ') + "out+='";
+				return "';" + code.replace(/\\'/g, "'").replace(/\\\\/g,"\\").replace(/[\r\t\n]/g, ' ') + ";out+='";
 			})
 			+ "';return out;")
 			.replace(/\n/g, '\\n')


### PR DESCRIPTION
My template (yes, I've changed syntax ;)):

``` html
<table><tbody>
  <% it.articles.forEach(function (a) { %>
    <tr>
      <td><%= a.title %></td>
      <td><%= a.title_urlized %></td>
    </tr>
  <% }) %>
</tbody></table>
```

This will fail with:

```
(...)<tbody>'; it.articles.forEach(function (a) { out+='<tr><td>'+( a.title )+'</td><td>'+( a.title_urlized )+'</td></tr>'; }) out+='</tbody>(...)
```

This is of course because of missing trailing semicolon after forEach. I can put it there manually in my template (and it works then) but IMHO it would be better if it were working automatically.

I'm not sure if my fix is correct, but it do the job for me.
