### PR TITLE
Replace `x.toString()` with `""+x` in encode

### DIFF
--- a/benchmarks/templating/doT.js
+++ b/benchmarks/templating/doT.js
@@ -64,7 +64,7 @@
 				return cstart + code.replace(/\\'/g, "'").replace(/\\\\/g,"\\").replace(/[\r\t\n]/g, ' ') + cend;
 			})
 			.replace(c.encode, function(match, code) {
-				return cstart + code.replace(/\\'/g, "'").replace(/\\\\/g, "\\").replace(/[\r\t\n]/g, ' ') + ").toString().replace(/&(?!\\w+;)/g, '&#38;').split('<').join('&#60;').split('>').join('&#62;').split('" + '"' + "').join('&#34;').split(" + '"' + "'" + '"' + ").join('&#39;').split('/').join('&#47;'" + cend;
+				return cstart + '(""+(' + code.replace(/\\'/g, "'").replace(/\\\\/g, "\\").replace(/[\r\t\n]/g, ' ') + "))).replace(/&(?!\\w+;)/g, '&#38;').split('<').join('&#60;').split('>').join('&#62;').split('" + '"' + "').join('&#34;').split(" + '"' + "'" + '"' + ").join('&#39;').split('/').join('&#47;'" + cend;
 			})
 			.replace(c.evaluate, function(match, code) {
 				return "';" + code.replace(/\\'/g, "'").replace(/\\\\/g,"\\").replace(/[\r\t\n]/g, ' ') + "out+='";

--- a/doT.js
+++ b/doT.js
@@ -64,7 +64,7 @@
 				return cstart + code.replace(/\\'/g, "'").replace(/\\\\/g,"\\").replace(/[\r\t\n]/g, ' ') + cend;
 			})
 			.replace(c.encode, function(match, code) {
-				return cstart + code.replace(/\\'/g, "'").replace(/\\\\/g, "\\").replace(/[\r\t\n]/g, ' ') + ").toString().replace(/&(?!\\w+;)/g, '&#38;').split('<').join('&#60;').split('>').join('&#62;').split('" + '"' + "').join('&#34;').split(" + '"' + "'" + '"' + ").join('&#39;').split('/').join('&#47;'" + cend;
+				return cstart + '(""+(' + code.replace(/\\'/g, "'").replace(/\\\\/g, "\\").replace(/[\r\t\n]/g, ' ') + "))).replace(/&(?!\\w+;)/g, '&#38;').split('<').join('&#60;').split('>').join('&#62;').split('" + '"' + "').join('&#34;').split(" + '"' + "'" + '"' + ").join('&#39;').split('/').join('&#47;'" + cend;
 			})
 			.replace(c.evaluate, function(match, code) {
 				return "';" + code.replace(/\\'/g, "'").replace(/\\\\/g,"\\").replace(/[\r\t\n]/g, ' ') + "out+='";


### PR DESCRIPTION
This prevents encode (`{{! ... }}`) throwing errors when the template data contains a `null` or `undefined` (as `null.toString` is not a method), instead simply interpolating that value into the template by using type coercion. It might be preferable to interpolate an empty string, long-term.

I did some simple benchmarking by changing the included `benchmarks/templatesBench.js` to use encoding tags `{{!` in place of simple interpolation `{{=`, and could not detect a statistically significant difference in performance between the two implementations. It's conceivable this could vary in other VMs (only tested in node), however, given that encoding tags are nearly two orders of magnitude slower in the benchmarks than raw interpolation, this could be considered a secondary priority.

At any rate, we're using this modification for a project I'm working on where we actually encode by default (we have `{{=` do encoding and `{{!=` for raw interpolation). doT is a beautifully simple, small, and fast templating module - I'm aware that encoding by default we lose some performance, but it seems an necessary trade-off given the importance of preventing XSS vulnerabilities.

Anyway, we love doT, and hope this can help make it more awesome. If there's a good reason `.toString` is better here I'd love to hear it, since it could impact the desirability of our local modifications. Thanks!
