### PR TITLE
avoid undefined / type errors for complex / deep / nested object trees the brute force way

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -23,6 +23,7 @@
 	doT.templateSettings = {
 		evaluate:    /\{\{([\s\S]+?)\}\}/g,
 		interpolate: /\{\{=([\s\S]+?)\}\}/g,
+		interpolateSafe: /\{\{~([\s\S]+?)\}\}/g,
 		encode:      /\{\{!([\s\S]+?)\}\}/g,
 		use:         /\{\{#([\s\S]+?)\}\}/g, //compile time evaluation
 		define:      /\{\{##\s*([\w\.$]+)\s*(\:|=)([\s\S]+?)#\}\}/g, //compile time defs
@@ -67,6 +68,9 @@
 			.replace(c.interpolate, function(match, code) {
 				return cstart + code.replace(/\\'/g, "'").replace(/\\\\/g,"\\").replace(/[\r\t\n]/g, ' ') + cend;
 			})
+			.replace(c.interpolateSafe, function(match, code) {
+              			  return "';" + "var val = ''; try{val = " + code.replace(/\\'/g, "'").replace(/\\\\/g,"\\").replace(/[\r\t\n]/g, ' ') + ";}catch(e){}; out+= val + '";
+            		})
 			.replace(c.encode, function(match, code) {
 				return cstart + code.replace(/\\'/g, "'").replace(/\\\\/g, "\\").replace(/[\r\t\n]/g, ' ') + ").toString().replace(/&(?!\\w+;)/g, '&#38;').split('<').join('&#60;').split('>').join('&#62;').split('" + '"' + "').join('&#34;').split(" + '"' + "'" + '"' + ").join('&#39;').split('/').join('&#47;'" + cend;
 			})


### PR DESCRIPTION
I'm not sure it's the best way, but I added a new "safe" interpolation option that will eval to '' if anything "bad" happens. (e.g. one of the objects is null or undefined, or simply you got an exception)
This is common in template languages (e.g. in Freemarker and VTL the ${! prefix )

I used {{~ }} for this notation, (e.g. if {{~a.b.c}} is called and b is undefined, it will return '' gracefully)

Since it's a new interpolation type, I think that if not used, it's only a very small performance issue (of course that the try catch is a very slow and bad practice, but doing {{= typeof a.b == 'undefined' ? '' : a.b}} is worse in my opinion (in terms of programmer productivity

I will not be offended and will still love DoT.js if you reject this pull request, it's one of my first ones

any comments are welcome, be gentle please... ;)
