### PR TITLE
Fix global leak in node.js

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -26,7 +26,7 @@
 		compile:  undefined  //fn, for express
 	};
 
-	var global = (function(){ return this || (0,eval)('this'); }());
+	var global = (function(){ return (module && module.exports) || this || (0,eval)('this'); }());
 
 	if (typeof module !== 'undefined' && module.exports) {
 		module.exports = doT;


### PR DESCRIPTION
Modules should not leak to the global namespace in node.js, this should fix that global leak.
