### PR TITLE
Add basic support for the Express framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Compile tool to compile dot templates into js (thanks to @Katahdin https://githu
 
 	./bin/dottojs -s examples/views -d out/views
 
+Added support for the Express framework (http://expressjs.com) in the node module.
+
 ## Notes:
     doU.js is here only so that legacy external tests do not break. Use doT.js.
     doT.js with doT.templateSettings.append=false provides the same performance as doU.js.

--- a/index.js
+++ b/index.js
@@ -132,3 +132,31 @@ InstallDots.prototype.compileAll = function() {
 	}
 	return this.__rendermodule;
 };
+
+
+
+/* Express framework 3.0.x support (http://expressjs.com) */
+
+doT.__express = function (path, options, callback) {
+	var template, 
+		string,
+		c = options.c || null,
+		def = options.def || {};
+
+	fs.readFile(path, function (err, data) {
+		if (err) {
+			return callback(err);
+		}
+
+		// Don't break the app if doT throws
+		try {
+			template = doT.template(data, c, def);
+		} catch(err) {
+			return callback(err);
+		}
+		
+		string = template(options);
+
+		return callback(null, string);
+	});	
+};


### PR DESCRIPTION
I added a single function to the node module (index.js) to support the Express framework.

No dependencies. The main doT.js remains untouched.

I guess there's reasons for this to be in its own module/repo, as in https://github.com/cstigler/express-dot and also reasons for this to be included in doT.

You could also have an express.js file in the repo with some more functionality (like cache support) and require it in index.js

I think it's useful to just include the doT module in for project and use it right away with Express,
which seems to be widely adopted (I don't know statistically). I've been using it like that for a while.

Usage in an Express app is simple, as expected:

    app.set('view engine', 'dot');

if you're using .dot files. Or:

    app.engine('html', require('dot').__express);
    app.use('view engine', 'html');

if you want to use any other extension.

I hope this is useful if it makes sense to you.

Happy new year.