### PR TITLE
Template Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/doT.js
+++ b/doT.js
@@ -204,12 +204,11 @@
                 code = unescape(fnParam);
                 if(doT.helpers){
                     if(doT.helpers[fn]){
-                        code = doT.helpers[fn].toString().replace(/\r|\n|\t|\/\*[\s\S]*?\*\//g,'');
+                        code = doT.helpers[fn].toString().replace(/\r|\n|\t|\/\*[\s\S]*?\*\//g,'') + ')(' + fnParam;
                     }else{
                         console.log('Could not find helper method ' + fn + ' for code: ' + code);
                     }
                 }
-                cse.end = ')(' + fnParam + ')+\'';
                 return cse.start + code + cse.end;
             })
 			.replace(c.conditional || skip, function(m, elsecase, code) {

--- a/doT.js
+++ b/doT.js
@@ -21,7 +21,8 @@
 			varname:	'it',
 			strip:		true,
 			append:		true,
-			selfcontained: false
+			selfcontained: false,
+			alsoNegate: [] // will count as 'false' in a conditional
 		},
 		helpers: undefined,
 		template: undefined, //fn, compile template
@@ -213,8 +214,8 @@
             })
 			.replace(c.conditional || skip, function(m, elsecase, code) {
 				return elsecase ?
-					(code ? "';}else if(" + unescape(code) + "){out+='" : "';}else{out+='") :
-					(code ? "';if(" + unescape(code) + "){out+='" : "';}out+='");
+					(code ? "';}else if(" + unescape(code) + " && " + JSON.stringify(c.alsoNegate) + ".indexOf(" + unescape(code) + ") === -1){out+='" : "';}else{out+='") :
+					(code ? "';if(" + unescape(code) + " && " + JSON.stringify(c.alsoNegate) + ".indexOf(" + unescape(code) + ") === -1){out+='" : "';}out+='");
 			})
 			.replace(c.iterate || skip, function(m, iterate, vname, iname) {
 				if (!iterate) return "';} } out+='";

--- a/doT.js
+++ b/doT.js
@@ -84,6 +84,97 @@
 		return code.replace(/\\('|\\)/g, "$1").replace(/[\r\t\n]/g, ' ');
 	}
 
+	// return union of any number of arrays
+	var _union = doT.union = function(array){
+		var argsLength = arguments.length,
+			result = [],
+			thisArray = [],
+			thisArrayLength = 0,
+			i = 0,
+			j = 0;
+		for(i; i < argsLength; i++){
+			thisArray = arguments[i];
+			thisArrayLength = thisArray.length;
+			j = 0;
+			for(j; j < thisArrayLength; j++){
+				if(result.indexOf(thisArray[j]) < 0){
+					result.push(thisArray[j]);
+				}
+			}
+		}
+		return result;
+	}
+
+	// Given a string, returns an array of properties on c.varname
+	// input: 'it.age === 0', 'it'
+	// output: [age]
+	// TODO: recursively check for..in
+	var _getVariables = doT.getVariables = function(str, varname){
+		var words = (typeof str === 'undefined') ? [] : str.split(/\s/g),
+			len = words.length,
+			vars = [],
+			prop,
+			i = 0;
+		for(i; i < len; i++){
+			// check to see if it has the var
+			if(words[i].indexOf(varname + '.') >= 0){
+				// grab everything after variable + dot
+				var splitByVar = words[i].split(varname + '.');
+				if(splitByVar.length > 1){
+					// get first chunk that matches valid javascript variable characters
+					prop = splitByVar[1].match(/[a-zA-Z_$][0-9a-zA-Z_$]*/i)[0];
+					// only add if doesn't exist already
+					if(vars.indexOf(prop) < 0){
+						vars.push(prop);
+					}
+				}
+			}
+		}
+		return vars;
+	};
+
+	doT.getDependencies = function(tmpl, c, def){
+		c = c || doT.templateSettings;
+		var deps = [],
+			cse = c.append ? startend.append : startend.split, needhtmlencode, sid = 0, indv,
+			str = (c.use || c.define) ? resolveDefs(c, tmpl, def || {}) : tmpl;
+
+		str = ("var out='" + (c.strip ? str.replace(/(^|\r|\n)\t* +| +\t*(\r|\n|$)/g,' ')
+					.replace(/\r|\n|\t|\/\*[\s\S]*?\*\//g,''): str)
+			.replace(/'|\\/g, '\\$&')
+			.replace(c.interpolate || skip, function(m, code) {
+				deps = _union(deps, _getVariables(code, c.varname));
+				return cse.start + unescape(code) + cse.end;
+			})
+			.replace(c.encode || skip, function(m, code) {
+				//console.log('encode: ' + code);
+				deps = _union(deps, _getVariables(code, c.varname));
+				needhtmlencode = true;
+				return cse.start + unescape(code) + cse.endencode;
+			})
+			.replace(c.conditional || skip, function(m, elsecase, code) {
+				//console.log('conditional: ' + code);
+				deps = _union(deps, _getVariables(code, c.varname));
+				return elsecase ?
+					(code ? "';}else if(" + unescape(code) + "){out+='" : "';}else{out+='") :
+					(code ? "';if(" + unescape(code) + "){out+='" : "';}out+='");
+			})
+			.replace(c.iterate || skip, function(m, iterate, vname, iname) {
+				//console.log('iterate: ' + iterate);
+				deps = _union(deps, _getVariables(iterate, c.varname));
+				if (!iterate) return "';} } out+='";
+				sid+=1; indv=iname || "i"+sid; iterate=unescape(iterate);
+				return "';var arr"+sid+"="+iterate+";if(arr"+sid+"){var "+vname+","+indv+"=-1,l"+sid+"=arr"+sid+".length-1;while("+indv+"<l"+sid+"){"+vname+"=arr"+sid+"["+indv+"+=1];out+='";
+			})
+			.replace(c.evaluate || skip, function(m, code) {
+				//console.log('evaluate: ' + code);
+				deps = _union(deps, _getVariables(code, c.varname));
+				return "';" + unescape(code) + "out+='";
+			}));
+
+			return deps;
+	};
+
 	doT.template = function(tmpl, c, def) {
 		c = c || doT.templateSettings;
 		var cse = c.append ? startend.append : startend.split, needhtmlencode, sid = 0, indv,

--- a/doT.js
+++ b/doT.js
@@ -204,7 +204,7 @@
                 code = unescape(fnParam);
                 if(doT.helpers){
                     if(doT.helpers[fn]){
-                        code = doT.helpers[fn].toString();
+                        code = doT.helpers[fn].toString().replace(/\r|\n|\t|\/\*[\s\S]*?\*\//g,'');
                     }else{
                         console.log('Could not find helper method ' + fn + ' for code: ' + code);
                     }

--- a/test/bed/.test
+++ b/test/bed/.test
@@ -6,16 +6,16 @@
     {
         "input_file"        : "/boilerplate_template.html",
         "output_file_dir"   : "app/src/template/sections/",
-        "output_file_name"  : "{{@className it.name}}_template.html"
+        "output_file_name"  : "<%@className it.name%>_template.html"
     },
     {
         "input_file"        : "/boilerplate_view.js",
         "output_file_dir"   : "app/src/views/sections/",
-        "output_file_name"  : "{{@className it.name}}View.js"
+        "output_file_name"  : "<%@className it.name%>View.js"
     },
     {
         "input_file"        : "/boilerplate_style.scss",
         "output_file_dir"   : "app/sass/sections/",
-        "output_file_name"  : "_{{@className it.name}}.scss"
+        "output_file_name"  : "_<%@className it.name%>.scss"
     }]
 }

--- a/test/bed/.test
+++ b/test/bed/.test
@@ -1,0 +1,21 @@
+{
+    "output_file_dir"   : "/",
+    "file_filter"       : ["!.DS_Store", "!thumbs.db"],
+    "dir_filter"        : ["!.svn", "!.git", "!.sass-cache"],
+    "file_renames" : [
+    {
+        "input_file"        : "/boilerplate_template.html",
+        "output_file_dir"   : "app/src/template/sections/",
+        "output_file_name"  : "{{@className it.name}}_template.html"
+    },
+    {
+        "input_file"        : "/boilerplate_view.js",
+        "output_file_dir"   : "app/src/views/sections/",
+        "output_file_name"  : "{{@className it.name}}View.js"
+    },
+    {
+        "input_file"        : "/boilerplate_style.scss",
+        "output_file_dir"   : "app/sass/sections/",
+        "output_file_name"  : "_{{@className it.name}}.scss"
+    }]
+}

--- a/test/bed/cond.html
+++ b/test/bed/cond.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+    <head>
+
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <title>My Project Name</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width">
+
+        <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+        <link rel="stylesheet" href="assets/css/bootstrap/bootstrap.css">
+        <link rel="stylesheet" href="assets/css/bootstrap/responsive.css">
+        <link rel="stylesheet" href="assets/css/main.css">
+
+    </head>
+
+    <body>
+
+        <script id="require-lib" data-main="src/config" src="src/libs/require.js"></script>
+
+        <h1>Project: Test</h1>
+
+        <%? it.hasLiveReload %>
+        <script id="live-reload">// live reload snippet, this is removed by build script for production
+        document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1"></' + 'script>')</script>
+        <%?%>
+
+    </body>
+
+</html>

--- a/test/bed/interpolate.html
+++ b/test/bed/interpolate.html
@@ -1,0 +1,14 @@
+{{
+{
+  "name" : "<%=it.name%>",
+  "description" : "<%=it.description%>"
+}
+}}
+
+{{debug this}}
+
+<div>
+
+    <h1><%=it.name%></h1>
+
+</div>

--- a/test/bed/test.js
+++ b/test/bed/test.js
@@ -3,10 +3,10 @@ define([
     'underscore',
     'backbone',
     'views/BaseView',
-    'hbs!template/{{@className it.name}}_template'
+    'hbs!template/<%@className it.name%>_template'
 ], function($, _, Backbone, BaseView, myTemplate){
 
-    var {{@className it.name}}Boilerplate = BaseView.extend({
+    var <%@className it.name%>Boilerplate = BaseView.extend({
 
         events: {
             // events here
@@ -15,7 +15,7 @@ define([
 
         vent: {}, // event map passed in
 
-        className: {{@className it.name}},
+        className: <%@className it.name%>,
 
         initialize: function( options ){
 
@@ -40,9 +40,8 @@ define([
             return this;
         }
 
-
     });
 
-    return {{@className it.name}}Boilerplate;
+    return <%@className it.name%>Boilerplate;
 
 });

--- a/test/bed/test.js
+++ b/test/bed/test.js
@@ -1,0 +1,48 @@
+define([
+    'jquery',
+    'underscore',
+    'backbone',
+    'views/BaseView',
+    'hbs!template/{{@className it.name}}_template'
+], function($, _, Backbone, BaseView, myTemplate){
+
+    var {{@className it.name}}Boilerplate = BaseView.extend({
+
+        events: {
+            // events here
+            // 'click .submit': 'submit'
+        },
+
+        vent: {}, // event map passed in
+
+        className: {{@className it.name}},
+
+        initialize: function( options ){
+
+            // pass in event map/aggregator & combine with base view
+            this.vent = (options) ? options.vent || {} : {};
+            this.events = _.extend({}, this.events, this.genericEvents);
+            this.delegateEvents();
+
+            // make sure all methods are executed in correct context
+            _.bindAll(this, 'render');
+
+            BaseView.prototype.initialize.call(this, options);
+
+            return this;
+        },
+
+        render: function(){
+            // compile template
+            var compiledTemplate = myTemplate({});
+            this.$el.html(compiledTemplate);
+
+            return this;
+        }
+
+
+    });
+
+    return {{@className it.name}}Boilerplate;
+
+});

--- a/test/testCond.js
+++ b/test/testCond.js
@@ -1,0 +1,38 @@
+var assert = require("assert"),
+    path = require('path'),
+    fs = require('fs'),
+    doT = require("../doT");
+
+doT.templateSettings = {
+        evaluate:    /\<\%([\s\S]+?)\%\>/g,
+        interpolate: /\<\%=([\s\S]+?)\%\>/g,
+        encode:      /\<\%!([\s\S]+?)\%\>/g,
+        helper:      /\<\%@([\s\S]+?)\%\>/g,
+        use:         /\<\%#([\s\S]+?)\%\>/g,
+        define:      /\<\%##\s*([\w\.$]+)\s*(\:|=)([\s\S]+?)#\%\>/g,
+        conditional: /\<\%\?(\?)?\s*([\s\S]*?)\s*\%\>/g,
+        iterate:     /\<\%~\s*(?:\}\}|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*\%\>)/g,
+        varname: 'it',
+        strip: false,
+        append: true,
+        selfcontained: false,
+        alsoNegate: ['false', 'no', 'n']
+    };
+
+
+describe('conditional', function(){
+    it('should apply additional negations', function(){
+        var data = fs.readFileSync(path.resolve(__dirname, 'bed/cond.html'));
+        var templateFn = doT.template(data.toString());
+        var out1 = templateFn({'hasLiveReload': "false"});
+        assert.equal(out1.indexOf('<script id="live-reload">'), -1);
+        var out2 = templateFn({'hasLiveReload': false});
+        assert.equal(out2.indexOf('<script id="live-reload">'), -1);
+        var out3 = templateFn({'hasLiveReload': "no"});
+        assert.equal(out3.indexOf('<script id="live-reload">'), -1);
+        var out4 = templateFn({'hasLiveReload': "n"});
+        assert.equal(out4.indexOf('<script id="live-reload">'), -1);
+        var out5 = templateFn({'hasLiveReload': "yes"});
+        assert.notEqual(out5.indexOf('<script id="live-reload">'), -1);
+    });
+});

--- a/test/testDeps.js
+++ b/test/testDeps.js
@@ -1,0 +1,58 @@
+var assert = require("assert"), doT = require("../doT");
+
+describe('doT', function(){
+    var interpolation = "<div>Hi {{=it.name}}!</div><div>{{=it.age || ''}}</div>",
+        interpolationDeps = doT.getDependencies(interpolation),
+        // TODO: how to properly grab dependencies from evaluation?
+        // evaluation = "{{ for(var prop in it) { }}<div>{{=prop}}</div>{{ } }}",
+        // evaluationDeps = doT.getDependencies(evaluation);
+        conditionals = "{{? it.name }}<div>Oh, I love your name, {{=it.name}}!</div>{{?? it.age === 0}}<div>Guess nobody named you yet!</div>{{??}}You are {{=it.age}} and still don't have a name?{{?}}",
+        conditionalsDeps = doT.getDependencies(conditionals),
+        arrays = "{{~it.array :value:index}}<div>{{=value}}!</div>{{~}}",
+        arraysDeps = doT.getDependencies(arrays);
+        encode = "Visit {{!it.uri}}",
+        encodeDeps = doT.getDependencies(encode);
+
+    describe('union', function(){
+      it('should remove duplicates and return the union of multiple arrays', function(){
+        assert.equal(JSON.stringify(['age', 'name', 'sex']), JSON.stringify(doT.union(['age', 'name'], ['age', 'sex'], ['name'])));
+      });
+    });
+
+    describe('get variables', function(){
+      it('should give back vars', function(){
+        assert.equal(JSON.stringify(['age', 'name', 'sex']), JSON.stringify(doT.getVariables('{{? asdf @#(*($@ it.age !@,,, it.age <div>it.name</div> <header>.it.name</header> it.sex', 'it')));
+      });
+    });
+
+    describe('get interpolation dependencies', function(){
+      it('should give back all dependencies', function(){
+        assert.equal(JSON.stringify(['name', 'age']), JSON.stringify(interpolationDeps));
+      });
+    });
+
+    describe('get conditional dependencies', function(){
+      it('should give back all dependencies', function(){
+        assert.equal(JSON.stringify(['name', 'age']), JSON.stringify(conditionalsDeps));
+      });
+    });
+
+    describe('get array dependencies', function(){
+      it('should give back all dependencies', function(){
+        assert.equal(JSON.stringify(['array']), JSON.stringify(arraysDeps));
+      });
+    });
+
+    describe('test no dependencies', function(){
+      it('should return an empty array of dependencies', function(){
+        assert.equal(0, doT.getDependencies('<html><head></head><body><div>myTest</div><h1>MyTitle</h1></body></html>').length);
+        assert.equal(0, doT.getDependencies('<html><head></head><body><div id="it.test">myTest</div><h1 class="it-test">MyTitle</h1></body></html>').length);
+      });
+    });
+
+    describe('get encoded dependencies', function(){
+      it('should give back all dependencies', function(){
+        assert.equal(JSON.stringify(['uri']), JSON.stringify(encodeDeps));
+      });
+    });
+});

--- a/test/testHelpers.js
+++ b/test/testHelpers.js
@@ -4,9 +4,9 @@ var assert = require("assert"),
     doT = require("../doT");
 
 describe('doT Helpers', function(){
-    var basictemplate = "<div>{{@capitalize it.name}}</div>",
+    var basictemplate = "<div><%@capitalize it.name%></div>",
         basiccompiled = null,
-        uppercaseTemplate = "<div>{{@uppercase it.name}}</div>",
+        uppercaseTemplate = "<div><%@uppercase it.name%></div>",
         uppercaseCompiled = null,
         uppercase = function(val){ return val.toUpperCase(); },
         capitalize = function(val){ return val.charAt(0).toUpperCase() + val.slice(1);},
@@ -22,72 +22,72 @@ describe('doT Helpers', function(){
             return sName;
         };
 
-    // doT.templateSettings = {
-    //     evaluate:    /\<\%([\s\S]+?)\%\>/g,
-    //     interpolate: /\<\%=([\s\S]+?)\%\>/g,
-    //     encode:      /\<\%!([\s\S]+?)\%\>/g,
-    //     helper:      /\<\%@([\s\S]+?)\%\>/g,
-    //     use:         /\<\%#([\s\S]+?)\%\>/g,
-    //     define:      /\<\%##\s*([\w\.$]+)\s*(\:|=)([\s\S]+?)#\%\>/g,
-    //     conditional: /\<\%\?(\?)?\s*([\s\S]*?)\s*\%\>/g,
-    //     iterate:     /\<\%~\s*(?:\}\}|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*\%\>)/g,
-    //     varname: 'it',
-    //     strip: false,
-    //     append: true,
-    //     selfcontained: false
-    // };
+    doT.templateSettings = {
+        evaluate:    /\<\%([\s\S]+?)\%\>/g,
+        interpolate: /\<\%=([\s\S]+?)\%\>/g,
+        encode:      /\<\%!([\s\S]+?)\%\>/g,
+        helper:      /\<\%@([\s\S]+?)\%\>/g,
+        use:         /\<\%#([\s\S]+?)\%\>/g,
+        define:      /\<\%##\s*([\w\.$]+)\s*(\:|=)([\s\S]+?)#\%\>/g,
+        conditional: /\<\%\?(\?)?\s*([\s\S]*?)\s*\%\>/g,
+        iterate:     /\<\%~\s*(?:\}\}|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*\%\>)/g,
+        varname: 'it',
+        strip: false,
+        append: true,
+        selfcontained: false
+    };
 
     // register helpers
     doT.registerHelper('capitalize', capitalize);
     doT.registerHelper('uppercase', uppercase);
     doT.registerHelper('className', sanitizeClassName);
 
-    // basiccompiled = doT.template(basictemplate);
-    // uppercaseCompiled = doT.template(uppercaseTemplate);
+    basiccompiled = doT.template(basictemplate);
+    uppercaseCompiled = doT.template(uppercaseTemplate);
 
-    // describe('register helper', function(){
-    //     it('should register', function(){
-    //         assert.equal("function", typeof doT.helpers['capitalize']);
-    //         assert.equal("function", typeof doT.helpers['uppercase']);
-    //     });
-    // });
+    describe('register helper', function(){
+        it('should register', function(){
+            assert.equal("function", typeof doT.helpers['capitalize']);
+            assert.equal("function", typeof doT.helpers['uppercase']);
+        });
+    });
 
-    // describe('#template()', function(){
-    //     it('should return a function', function(){
-    //        assert.equal("function", typeof basiccompiled);
-    //     });
-    //     it('should work with capitalize fn helper', function(){
-    //         assert.equal('<div>Nick</div>', basiccompiled({'name': 'nick'}));
-    //     });
-    //     it('should work with uppercase fn helper', function(){
-    //         assert.equal('<div>NICK</div>', uppercaseCompiled({'name': 'nick'}));
-    //         assert.equal('<div>NICK JONAS</div>', uppercaseCompiled({'name': 'nick jonas'}));
-    //     });
-    // });
+    describe('#template()', function(){
+        it('should return a function', function(){
+           assert.equal("function", typeof basiccompiled);
+        });
+        it('should work with capitalize fn helper', function(){
+            var test = basiccompiled({'name': 'nick'});
+            assert.equal('<div>Nick</div>', basiccompiled({'name': 'nick'}));
+        });
+        it('should work with uppercase fn helper', function(){
+            assert.equal('<div>NICK</div>', uppercaseCompiled({'name': 'nick'}));
+            assert.equal('<div>NICK JONAS</div>', uppercaseCompiled({'name': 'nick jonas'}));
+        });
+    });
 
-    // describe('external file template', function(){
-    //     it('should correctly template with helper', function(){
-    //         var file = fs.readFileSync(path.join(__dirname, 'bed/.test')),
-    //             template = file.toString(),
-    //             compiled = doT.template(template);
-    //        assert.equal("function", typeof compiled);
-    //        var out = compiled({'name': 'nick jonas'});
-    //        assert.notEqual(out.indexOf('NickJonasView.js'), -1);
-    //        assert.notEqual(out.indexOf('_NickJonas.scss'), -1);
-    //        assert.notEqual(out.indexOf('NickJonas_template.html'), -1);
-    //     });
-    // });
+    describe('external file template', function(){
+        it('should correctly template with helper', function(){
+            var file = fs.readFileSync(path.join(__dirname, 'bed/.test')),
+                template = file.toString(),
+                compiled = doT.template(template);
+           assert.equal("function", typeof compiled);
+           var out = compiled({'name': 'nick jonas'});
+           assert.notEqual(out.indexOf('NickJonasView.js'), -1);
+           assert.notEqual(out.indexOf('_NickJonas.scss'), -1);
+           assert.notEqual(out.indexOf('NickJonas_template.html'), -1);
+        });
+    });
 
-    // describe('external file template', function(){
-    //     it('should correctly template with helper', function(){
-    //         var file = fs.readFileSync(path.join(__dirname, 'bed/test.js')),
-    //             template = file.toString(),
-    //             compiled = doT.template(template);
-    //        assert.equal("function", typeof compiled);
-    //        var out = compiled({'name': 'nick jonas'});
-    //        console.log(out);
-    //     });
-    // });
+    describe('external file template', function(){
+        it('should correctly template with helper', function(){
+            var file = fs.readFileSync(path.join(__dirname, 'bed/test.js')),
+                template = file.toString(),
+                compiled = doT.template(template);
+           assert.equal("function", typeof compiled);
+           var out = compiled({'name': 'nick jonas'});
+        });
+    });
 
 doT.templateSettings = {
         evaluate:    /\<\%([\s\S]+?)\%\>/g,

--- a/test/testHelpers.js
+++ b/test/testHelpers.js
@@ -1,4 +1,7 @@
-var assert = require("assert"), doT = require("../doT");
+var assert = require("assert"),
+    path = require('path'),
+    fs = require('fs'),
+    doT = require("../doT");
 
 describe('doT Helpers', function(){
     var basictemplate = "<div>{{@capitalize it.name}}</div>",
@@ -6,32 +9,72 @@ describe('doT Helpers', function(){
         uppercaseTemplate = "<div>{{@uppercase it.name}}</div>",
         uppercaseCompiled = null,
         uppercase = function(val){ return val.toUpperCase(); },
-        capitalize = function(val){ return val.charAt(0).toUpperCase() + val.slice(1);};
+        capitalize = function(val){ return val.charAt(0).toUpperCase() + val.slice(1);},
+        sanitizeClassName = function(name){
+            var sName = name,
+                allWords = sName.split(/\s+/g),
+                i = 0;
+            for(i; i < allWords.length; i++){
+                allWords[i] = allWords[i].charAt(0).toUpperCase() + allWords[i].slice(1);
+            }
+            sName = allWords.join('').trim();
+
+            return sName;
+        };
+
+    // doT.templateSettings = {
+    //     evaluate:    /\<\%([\s\S]+?)\%\>/g,
+    //     interpolate: /\<\%=([\s\S]+?)\%\>/g,
+    //     encode:      /\<\%!([\s\S]+?)\%\>/g,
+    //     helper:      /\<\%@([\s\S]+?)\%\>/g,
+    //     use:         /\<\%#([\s\S]+?)\%\>/g,
+    //     define:      /\<\%##\s*([\w\.$]+)\s*(\:|=)([\s\S]+?)#\%\>/g,
+    //     conditional: /\<\%\?(\?)?\s*([\s\S]*?)\s*\%\>/g,
+    //     iterate:     /\<\%~\s*(?:\}\}|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*\%\>)/g,
+    //     varname: 'it',
+    //     strip: false,
+    //     append: true,
+    //     selfcontained: false
+    // };
 
     // register helpers
     doT.registerHelper('capitalize', capitalize);
     doT.registerHelper('uppercase', uppercase);
+    doT.registerHelper('className', sanitizeClassName);
 
-    basiccompiled = doT.template(basictemplate);
-    uppercaseCompiled = doT.template(uppercaseTemplate);
+    // basiccompiled = doT.template(basictemplate);
+    // uppercaseCompiled = doT.template(uppercaseTemplate);
 
-    describe('register helper', function(){
-        it('should register', function(){
-            assert.equal("function", typeof doT.helpers['capitalize']);
-            assert.equal("function", typeof doT.helpers['uppercase']);
-        });
-    });
+    // describe('register helper', function(){
+    //     it('should register', function(){
+    //         assert.equal("function", typeof doT.helpers['capitalize']);
+    //         assert.equal("function", typeof doT.helpers['uppercase']);
+    //     });
+    // });
 
-    describe('#template()', function(){
-        it('should return a function', function(){
-           assert.equal("function", typeof basiccompiled);
-        });
-        it('should work with capitalize fn helper', function(){
-            assert.equal('<div>Nick</div>', basiccompiled({'name': 'nick'}));
-        });
-        it('should work with uppercase fn helper', function(){
-            assert.equal('<div>NICK</div>', uppercaseCompiled({'name': 'nick'}));
-            assert.equal('<div>NICK JONAS</div>', uppercaseCompiled({'name': 'nick jonas'}));
+    // describe('#template()', function(){
+    //     it('should return a function', function(){
+    //        assert.equal("function", typeof basiccompiled);
+    //     });
+    //     it('should work with capitalize fn helper', function(){
+    //         assert.equal('<div>Nick</div>', basiccompiled({'name': 'nick'}));
+    //     });
+    //     it('should work with uppercase fn helper', function(){
+    //         assert.equal('<div>NICK</div>', uppercaseCompiled({'name': 'nick'}));
+    //         assert.equal('<div>NICK JONAS</div>', uppercaseCompiled({'name': 'nick jonas'}));
+    //     });
+    // });
+
+    describe('external file template', function(){
+        it('should correctly template with helper', function(){
+            var file = fs.readFileSync(path.join(__dirname, 'bed/.test')),
+                template = file.toString(),
+                compiled = doT.template(template);
+           assert.equal("function", typeof compiled);
+           var out = compiled({'name': 'nick jonas'});
+           assert.notEqual(out.indexOf('NickJonasView.js'), -1);
+           assert.notEqual(out.indexOf('_NickJonas.scss'), -1);
+           assert.notEqual(out.indexOf('NickJonas_template.html'), -1);
         });
     });
 });

--- a/test/testHelpers.js
+++ b/test/testHelpers.js
@@ -1,0 +1,37 @@
+var assert = require("assert"), doT = require("../doT");
+
+describe('doT Helpers', function(){
+    var basictemplate = "<div>{{@capitalize it.name}}</div>",
+        basiccompiled = null,
+        uppercaseTemplate = "<div>{{@uppercase it.name}}</div>",
+        uppercaseCompiled = null,
+        uppercase = function(val){ return val.toUpperCase(); },
+        capitalize = function(val){ return val.charAt(0).toUpperCase() + val.slice(1);};
+
+    // register helpers
+    doT.registerHelper('capitalize', capitalize);
+    doT.registerHelper('uppercase', uppercase);
+
+    basiccompiled = doT.template(basictemplate);
+    uppercaseCompiled = doT.template(uppercaseTemplate);
+
+    describe('register helper', function(){
+        it('should register', function(){
+            assert.equal("function", typeof doT.helpers['capitalize']);
+            assert.equal("function", typeof doT.helpers['uppercase']);
+        });
+    });
+
+    describe('#template()', function(){
+        it('should return a function', function(){
+           assert.equal("function", typeof basiccompiled);
+        });
+        it('should work with capitalize fn helper', function(){
+            assert.equal('<div>Nick</div>', basiccompiled({'name': 'nick'}));
+        });
+        it('should work with uppercase fn helper', function(){
+            assert.equal('<div>NICK</div>', uppercaseCompiled({'name': 'nick'}));
+            assert.equal('<div>NICK JONAS</div>', uppercaseCompiled({'name': 'nick jonas'}));
+        });
+    });
+});

--- a/test/testHelpers.js
+++ b/test/testHelpers.js
@@ -65,16 +65,53 @@ describe('doT Helpers', function(){
     //     });
     // });
 
+    // describe('external file template', function(){
+    //     it('should correctly template with helper', function(){
+    //         var file = fs.readFileSync(path.join(__dirname, 'bed/.test')),
+    //             template = file.toString(),
+    //             compiled = doT.template(template);
+    //        assert.equal("function", typeof compiled);
+    //        var out = compiled({'name': 'nick jonas'});
+    //        assert.notEqual(out.indexOf('NickJonasView.js'), -1);
+    //        assert.notEqual(out.indexOf('_NickJonas.scss'), -1);
+    //        assert.notEqual(out.indexOf('NickJonas_template.html'), -1);
+    //     });
+    // });
+
+    // describe('external file template', function(){
+    //     it('should correctly template with helper', function(){
+    //         var file = fs.readFileSync(path.join(__dirname, 'bed/test.js')),
+    //             template = file.toString(),
+    //             compiled = doT.template(template);
+    //        assert.equal("function", typeof compiled);
+    //        var out = compiled({'name': 'nick jonas'});
+    //        console.log(out);
+    //     });
+    // });
+
+doT.templateSettings = {
+        evaluate:    /\<\%([\s\S]+?)\%\>/g,
+        interpolate: /\<\%=([\s\S]+?)\%\>/g,
+        encode:      /\<\%!([\s\S]+?)\%\>/g,
+        helper:      /\<\%@([\s\S]+?)\%\>/g,
+        use:         /\<\%#([\s\S]+?)\%\>/g,
+        define:      /\<\%##\s*([\w\.$]+)\s*(\:|=)([\s\S]+?)#\%\>/g,
+        conditional: /\<\%\?(\?)?\s*([\s\S]*?)\s*\%\>/g,
+        iterate:     /\<\%~\s*(?:\}\}|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*\%\>)/g,
+        varname: 'it',
+        strip: false,
+        append: true,
+        selfcontained: false
+    };
+
     describe('external file template', function(){
         it('should correctly template with helper', function(){
-            var file = fs.readFileSync(path.join(__dirname, 'bed/.test')),
+            var file = fs.readFileSync(path.join(__dirname, 'bed/interpolate.html')),
                 template = file.toString(),
                 compiled = doT.template(template);
            assert.equal("function", typeof compiled);
-           var out = compiled({'name': 'nick jonas'});
-           assert.notEqual(out.indexOf('NickJonasView.js'), -1);
-           assert.notEqual(out.indexOf('_NickJonas.scss'), -1);
-           assert.notEqual(out.indexOf('NickJonas_template.html'), -1);
+           var out = compiled({'name': 'nick jonas', 'description': 'heyo!'});
+
         });
     });
 });


### PR DESCRIPTION
Allows users to get dependencies from given templates.  NOTE: this does
not yet work for 'evaluate' templates, as this would involve running
the code through a full JS parser to extract dependencies

Example:

Given template string `<div>Hi {{=it.name}}!</div><div>{{=it.age || ''}}</div>` and varname `it`, it will return `['name', 'age']`
