### PR TITLE
Give priority to AMD detection

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -25,11 +25,10 @@
 		template: undefined, //fn, compile template
 		compile:  undefined  //fn, for express
 	};
-
-	if (typeof module !== 'undefined' && module.exports) {
-		module.exports = doT;
-	} else if (typeof define === 'function' && define.amd) {
+	if (typeof define === 'function' && define.amd) {
 		define(function(){return doT;});
+	} else if (typeof module !== 'undefined' && module.exports) {
+		module.exports = doT;
 	} else {
 		(function(){ return this || (0,eval)('this'); }()).doT = doT;
 	}


### PR DESCRIPTION
If one is using an environment like [App.js](http://appjs.org/) with an `AMD` loader (e.g. RequireJS), both `module` and `define` variables are set.

In this case, one should give priority to `AMD` detection, because `node` is only being used as a way to spawn a webkit and a window for a desktop application (among other things).