### PR TITLE
Fix for Uglify.js quirk

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -31,7 +31,7 @@
 	} else if (typeof define === 'function' && define.amd) {
 		define(function(){return doT;});
 	} else {
-		(function(){ return this || (0,eval)('this'); }()).doT = doT;
+		(0,function(){ return this || (0,eval)('this'); }()).doT = doT;
 	}
 
 	function encodeHTMLSource() {


### PR DESCRIPTION
The Uglify.js minifyer (used by r.js), compresses doT's global declaration fallback from this:

(function(){ return this || (0,eval)('this'); }()).doT = doT;

into this:

function(){ return this || (0,eval)('this'); }().doT = doT;

Which results in an error in safari/IOS. 

Adding a "(0," at the beginning forces uglify to keep the brackets, resulting in working compiled code.
