### PR TITLE
Fix minification issue when used with Microsoft.Web.Optimization framewo...

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -31,7 +31,7 @@
 	} else if (typeof define === 'function' && define.amd) {
 		define(function(){return doT;});
 	} else {
-		global = (function(){ return this || (0,eval)('this'); }());
+		global = (function(){ return this || (0,eval)('this') || window; }());
 		global.doT = doT;
 	}
 


### PR DESCRIPTION
...rk.

When Microsoft.Web.Optimization minifies the doT.js file, the fragment "return this || (0,eval)('this')" turns into "return this || eval('this')" which yields undefined (on Chrome). Adding "|| window" guarantees SOMETHING to hang doT off of.
