### PR TITLE
doT.runtime.js

### DIFF
--- a/doT.runtime.js
+++ b/doT.runtime.js
@@ -1,0 +1,7 @@
+String.prototype.encodeHTML = function() {
+  var encodeHTMLRules = { "&": "&#38;", "<": "&#60;", ">": "&#62;", '"': '&#34;', "'": '&#39;', "/": '&#47;' },
+      matchHTML = /&(?!#?\w+;)|<|>|"|'|\//g;
+  return function() {
+    return this ? this.replace(matchHTML, function(m) {return encodeHTMLRules[m] || m;}) : this;
+  };
+}();


### PR DESCRIPTION
I think it's necessary to have a runtime.js for doT.

When no templates get compiled during runtime ( all compiled when deploy ),  `doT.runtime.js` could provide the `encodeHTML` method for the execution of the templates at runtime. Sot that we could avoid include the whole `doT.js` which is much bigger.
