### PR TITLE
add a compile helper to compile to string

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -130,6 +130,10 @@
 		}
 	};
 
+  doT.compileToString = function(tmpl, def) {
+		return String(doT.compile(tmpl, def));
+	};
+
 	doT.compile = function(tmpl, def) {
 		return doT.template(tmpl, null, def);
 	};


### PR DESCRIPTION
Add a compileToString helper function to return the template function as String for template compilation at compilation time.
