### PR TITLE
Always install dottojs dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "test": "mocha"
   },
   "dependencies": {
-  },
-  "devDependencies": {
     "commander": "*",
     "uglify-js": "*",
-    "mkdirp": "*",
+    "mkdirp": "*"
+  },
+  "devDependencies": {
     "mocha":"*",
     "jshint":"*"
   }


### PR DESCRIPTION
doT installed as dependency provides dottojs binary, but it doesn't work:

```
$ ./node_modules/.bin/dottojs --help

module.js:340
    throw err;
          ^
Error: Cannot find module 'commander'
```
