### PR TITLE
move commander to dependency, not devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "test": "mocha"
   },
   "dependencies": {
+    "commander": "*"
   },
   "devDependencies": {
-    "commander": "*",
     "uglify-js": "*",
     "mkdirp": "*",
     "mocha":"*",


### PR DESCRIPTION
Generally I think dependencies of bin scripts for a project are dependencies. If you list it in `devDependencies` it will not be installed when people run `npm install`. I was trying to use the `dottojs` cli but was getting an error about commander not being found. 

This problem could be solved by having the user type `npm install --dev dot` but that is [terribly broken and will be deprecated](https://github.com/npm/npm/issues/6200).

By the way, I love doT, thanks a lot for a great library!