### PR TITLE
Add license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "engines": [
     "node >=0.2.6"
   ],
+  "license": "MIT",
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
