### PR TITLE
Add tests for whitespace stripping. Simplified semantics of the same

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -91,8 +91,7 @@
 		var cse = c.append ? startend.append : startend.split, needhtmlencode, sid = 0, indv,
 			str  = (c.use || c.define) ? resolveDefs(c, tmpl, def || {}) : tmpl;
 
-		str = ("var out='" + (c.strip ? str.replace(/(^|\r|\n)\t* +| +\t*(\r|\n|$)/g," ")
-					.replace(/\r|\n|\t|\/\*[\s\S]*?\*\//g,""): str)
+		str = ("var out='" + (c.strip ? str.replace(/\s+/g," ") : str)
 			.replace(/'|\\/g, "\\$&")
 			.replace(c.interpolate || skip, function(m, code) {
 				return cse.start + unescape(code) + cse.end;

--- a/test/testdoT.js
+++ b/test/testdoT.js
@@ -61,4 +61,15 @@ describe('doT', function(){
 		});
 	});
 
+	describe('whitespace stripping', function() {
+		function assert_match(actual, expected) {
+			assert(actual.match(expected), JSON.stringify(actual) + " did not match " + expected);
+		}
+		it('should replace stretches of whitespace with one whitespace', function() {
+			assert_match(doT.template('<div>    </div>')(), /^<div>\s<\/div>$/);
+		});
+		it('should recognize any whitespace as significant', function() {
+			assert_match(doT.template('<div>\n\r<img\n\tsrc="image.png">\n  </div>')(), /^<div>\s<img\ssrc="image.png">\s<\/div>$/);
+		});
+	});
 });


### PR DESCRIPTION
Before this change, the tests produced the following results:

For the input `<div>    </div>` (four spaces in a row), no spaces were stripped. The output was identical to the input.

For the input `<div>\n\r<img\n\tsrc="image.png">\n  </div>`, the following output was generated: `<div><imgsrc="image.png"> </div>`. Notice that the whitespace between `img` and `src` has been stripped entirely away, changing the semantical meaning of the HTML.

After this change, the same tests give the following output, respectively: `<div> </div>` (one space) and `<div> <img src="image.png"> </div>`. This mechanism is easier to understand, and less error prone: Any sequence of whitespace characters is replaced by one whitespace character.

Whitespace stripping still has problems. Whitespace should not be altered within `<pre>` and `<script>` blocks, for example. Inside `<script>`, replacing `\n` with ` ` will make line comments extend to the next lines, commenting out too much. However, I believe this change makes the whitespace stripping that's already present simpler and easier to understand.
