### PR TITLE
fix  encodeHTMLSource  when code = 0

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -31,7 +31,7 @@
 		var encodeHTMLRules = { "&": "&#38;", "<": "&#60;", ">": "&#62;", '"': "&#34;", "'": "&#39;", "/": "&#47;" },
 			matchHTML = doNotSkipEncoded ? /[&<>"'\/]/g : /&(?!#?\w+;)|<|>|"|'|\//g;
 		return function(code) {
-			return code ? code.toString().replace(matchHTML, function(m) {return encodeHTMLRules[m] || m;}) : "";
+			return code !== undefined ? code.toString().replace(matchHTML, function(m) {return encodeHTMLRules[m] || m;}) : "";
 		};
 	};
 


### PR DESCRIPTION
when encodeHTMLSource got a parameter  code = 0,  encodeHTMLSource will output  ''  , but the expected  output  is
'0'
