### PR TITLE
Fix `encodeHTML` with numeric zero issue

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -31,7 +31,7 @@
 		var encodeHTMLRules = { "&": "&#38;", "<": "&#60;", ">": "&#62;", '"': "&#34;", "'": "&#39;", "/": "&#47;" },
 			matchHTML = doNotSkipEncoded ? /[&<>"'\/]/g : /&(?!#?\w+;)|<|>|"|'|\//g;
 		return function(code) {
-			return code ? code.toString().replace(matchHTML, function(m) {return encodeHTMLRules[m] || m;}) : "";
+			return (code || typeof code === "number") ? code.toString().replace(matchHTML, function(m) {return encodeHTMLRules[m] || m;}) : "";
 		};
 	};
 


### PR DESCRIPTION
Related issue: https://github.com/olado/doT/issues/170

`{{?0}}` should turn into `"0"`, not empty string `""`
