### PR TITLE
use multiline in defs param (new PR)

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -73,7 +73,7 @@
 		.replace(c.use || skip, function(m, code) {
 			if (c.useParams) code = code.replace(c.useParams, function(m, s, d, param) {
 				if (def[d] && def[d].arg && param) {
-					var rw = (d+":"+param).replace(/'|\\/g, "_");
+					var rw = unescape((d+":"+param).replace(/'|\\/g, "_"));
 					def.__exp = def.__exp || {};
 					def.__exp[rw] = def[d].text.replace(new RegExp("(^|[^\\w$])" + def[d].arg + "([^\\w$])", "g"), "$1" + param + "$2");
 					return s + "def.__exp['"+rw+"']";

--- a/test/defines.test.js
+++ b/test/defines.test.js
@@ -19,6 +19,15 @@ describe('defines', function() {
         it('should render define', function(){
             testDef('{{##def.tmp:foo:<div>{{!foo}}</div>#}}{{ var bar = it.foo; }}{{# def.tmp:bar }}');
         });
+
+        it('should render define multiline params', function(){
+            testDef('{{##def.tmp:data:{{=data.openTag}}{{!data.foo}}{{=data.closeTag}}#}}\n' +
+                '{{# def.tmp:{\n' +
+                '   foo: it.foo,\n' +
+                '   openTag: "<div>",\n' +
+                '   closeTag: "</div>"\n' +
+                '} }}');
+        });
     });
 
     function testDef(tmpl, defines) {


### PR DESCRIPTION
Multiline params in defs for use object and test.

```
{{##def.snippet:data:
Sum a & b: {{= data.a + data.b}}
#}}

{{#def.snippet:{
  a:1,
  b:2
} }}
```