### PR TITLE
Ability to specify a source map or source url

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -121,7 +121,6 @@
 				return "';" + unescape(code, c.minify) + "out+='";
 			})
 			+ "';return out;" + surl)
-			.replace(/\n/g, "\\n").replace(/\t/g, '\\t').replace(/\r/g, "\\r")
 			.replace(/(\s|;|\}|^|\{)out\+='';/g, '$1').replace(/\+''/g, "");
 			//.replace(/(\s|;|\}|^|\{)out\+=''\+/g,'$1out+=');
 

--- a/doT.js
+++ b/doT.js
@@ -18,7 +18,7 @@
 			defineParams:/^\s*([\w$]+):([\s\S]+)/,
 			conditional: /\{\{\?(\?)?\s*([\s\S]*?)\s*\}\}/g,
 			iterate:     /\{\{~\s*(?:\}\}|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*\}\})/g,
-			url:				 /[\s]*(\/\/#[\s]+sourceURL=[\S]+)$/g,
+			url:				 /[\s]*(\/\/#[\s]+(sourceURL|sourceMappingURL)=[\S]+)$/g,
 			varname:	"it",
 			strip:		true,
 			append:		true,

--- a/doT.js
+++ b/doT.js
@@ -112,19 +112,20 @@
 			})
 			.replace(c.conditional || skip, function(m, elsecase, code) {
 				return elsecase ?
-					(code ? "`;}else if(" + unescape(code) + "){out+=`" : "`;}else{out+=`") :
-					(code ? "`;if(" + unescape(code) + "){out+=`" : "`;}out+=`");
+					(code ? "';}else if(" + unescape(code) + "){out+='" : "';}else{out+='") :
+					(code ? "';if(" + unescape(code) + "){out+='" : "';}out+='");
 			})
 			.replace(c.iterate || skip, function(m, iterate, vname, iname) {
-				if (!iterate) return "`;} } out+=`";
+				if (!iterate) return "';} } out+='";
 				sid+=1; indv=iname || "i"+sid; iterate=unescape(iterate);
-				return "`;var arr"+sid+"="+iterate+";if(arr"+sid+"){var "+vname+","+indv+"=-1,l"+sid+"=arr"+sid+".length-1;while("+indv+"<l"+sid+"){"
-					+vname+"=arr"+sid+"["+indv+"+=1];out+=`";
+				return "';var arr"+sid+"="+iterate+";if(arr"+sid+"){var "+vname+","+indv+"=-1,l"+sid+"=arr"+sid+".length-1;while("+indv+"<l"+sid+"){"
+					+vname+"=arr"+sid+"["+indv+"+=1];out+='";
 			})
 			.replace(c.evaluate || skip, function(m, code) {
-				return "`;" + unescape(code) + "out+=`";
+				return "';" + unescape(code) + "out+='";
 			})
-			+ "`;return out;" + surl)
+			+ "';return out;" + surl)
+			.replace(/\n/g, "\\n").replace(/\t/g, '\\t').replace(/\r/g, "\\r")
 			.replace(/(\s|;|\}|^|\{)out\+='';/g, '$1').replace(/\+''/g, "");
 			//.replace(/(\s|;|\}|^|\{)out\+=''\+/g,'$1out+=');
 

--- a/doT.js
+++ b/doT.js
@@ -18,6 +18,7 @@
 			defineParams:/^\s*([\w$]+):([\s\S]+)/,
 			conditional: /\{\{\?(\?)?\s*([\s\S]*?)\s*\}\}/g,
 			iterate:     /\{\{~\s*(?:\}\}|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*\}\})/g,
+			url:				 /(\/\/#[\s]+sourceURL=[\S]+)$/g,
 			varname:	"it",
 			strip:		true,
 			append:		true,
@@ -98,7 +99,7 @@
 		str = ("var out='" + (c.strip ? str.replace(/(^|\r|\n)\t* +| +\t*(\r|\n|$)/g," ")
 					.replace(/\r|\n|\t|\/\*[\s\S]*?\*\//g,""): str)
 			.replace(/'|\\/g, "\\$&")
-			.replace(/(\/\/#[\s]+sourceURL=[\S]+)$/g, function(m, code) {
+			.replace(c.url || skip, function(m, code) {
 				surl = code;
 				return '';
 			})

--- a/doT.js
+++ b/doT.js
@@ -18,7 +18,7 @@
 			defineParams:/^\s*([\w$]+):([\s\S]+)/,
 			conditional: /\{\{\?(\?)?\s*([\s\S]*?)\s*\}\}/g,
 			iterate:     /\{\{~\s*(?:\}\}|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*\}\})/g,
-			url:				 /(\/\/#[\s]+sourceURL=[\S]+)$/g,
+			url:				 /[\s]*(\/\/#[\s]+sourceURL=[\S]+)$/g,
 			varname:	"it",
 			strip:		true,
 			append:		true,

--- a/doT.js
+++ b/doT.js
@@ -112,20 +112,19 @@
 			})
 			.replace(c.conditional || skip, function(m, elsecase, code) {
 				return elsecase ?
-					(code ? "';}else if(" + unescape(code) + "){out+='" : "';}else{out+='") :
-					(code ? "';if(" + unescape(code) + "){out+='" : "';}out+='");
+					(code ? "`;}else if(" + unescape(code) + "){out+=`" : "`;}else{out+=`") :
+					(code ? "`;if(" + unescape(code) + "){out+=`" : "`;}out+=`");
 			})
 			.replace(c.iterate || skip, function(m, iterate, vname, iname) {
-				if (!iterate) return "';} } out+='";
+				if (!iterate) return "`;} } out+=`";
 				sid+=1; indv=iname || "i"+sid; iterate=unescape(iterate);
-				return "';var arr"+sid+"="+iterate+";if(arr"+sid+"){var "+vname+","+indv+"=-1,l"+sid+"=arr"+sid+".length-1;while("+indv+"<l"+sid+"){"
-					+vname+"=arr"+sid+"["+indv+"+=1];out+='";
+				return "`;var arr"+sid+"="+iterate+";if(arr"+sid+"){var "+vname+","+indv+"=-1,l"+sid+"=arr"+sid+".length-1;while("+indv+"<l"+sid+"){"
+					+vname+"=arr"+sid+"["+indv+"+=1];out+=`";
 			})
 			.replace(c.evaluate || skip, function(m, code) {
-				return "';" + unescape(code) + "out+='";
+				return "`;" + unescape(code) + "out+=`";
 			})
-			+ "';return out;" + surl)
-			.replace(/\n/g, "\\n").replace(/\t/g, '\\t').replace(/\r/g, "\\r")
+			+ "`;return out;" + surl)
 			.replace(/(\s|;|\}|^|\{)out\+='';/g, '$1').replace(/\+''/g, "");
 			//.replace(/(\s|;|\}|^|\{)out\+=''\+/g,'$1out+=');
 

--- a/doT.js
+++ b/doT.js
@@ -87,7 +87,7 @@
 	}
 
 	function unescape(code) {
-		return code.replace(/\\('|\\)/g, "$1").replace( /[\r\t\n]/g, " ");
+		return code.replace(/\\('|\\)/g, "$1").replace(/[\r\t\n]/g, " ");
 	}
 
 	doT.template = function(tmpl, c, def) {

--- a/doT.js
+++ b/doT.js
@@ -89,15 +89,19 @@
 		return code.replace(/\\('|\\)/g, "$1").replace( /[\r\t\n]/g, " ");
 	}
 
-	doT.template = function(tmpl, c, def, surl) {
+	doT.template = function(tmpl, c, def) {
 		c = c || doT.templateSettings;
-		surl = surl ? '//# sourceURL=' + surl : '';
+		var surl = '';
 		var cse = c.append ? startend.append : startend.split, needhtmlencode, sid = 0, indv,
 			str  = (c.use || c.define) ? resolveDefs(c, tmpl, def || {}) : tmpl;
 
 		str = ("var out='" + (c.strip ? str.replace(/(^|\r|\n)\t* +| +\t*(\r|\n|$)/g," ")
 					.replace(/\r|\n|\t|\/\*[\s\S]*?\*\//g,""): str)
 			.replace(/'|\\/g, "\\$&")
+			.replace(/(\/\/#[\s]+sourceURL=[\S]+)$/g, function(m, code) {
+				surl = code;
+				return '';
+			})
 			.replace(c.interpolate || skip, function(m, code) {
 				return cse.start + unescape(code) + cse.end;
 			})
@@ -139,7 +143,7 @@
 		}
 	};
 
-	doT.compile = function(tmpl, def, surl) {
-		return doT.template(tmpl, null, def, surl);
+	doT.compile = function(tmpl, def) {
+		return doT.template(tmpl, null, def);
 	};
 }());

--- a/doT.js
+++ b/doT.js
@@ -18,7 +18,6 @@
 			defineParams:/^\s*([\w$]+):([\s\S]+)/,
 			conditional: /\{\{\?(\?)?\s*([\s\S]*?)\s*\}\}/g,
 			iterate:     /\{\{~\s*(?:\}\}|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*\}\})/g,
-			minify: 		 /[\r\t\n]/g,
 			varname:	"it",
 			strip:		true,
 			append:		true,
@@ -86,8 +85,8 @@
 		});
 	}
 
-	function unescape(code, minify) {
-		return code.replace(/\\('|\\)/g, "$1").replace( minify || skip, " ");
+	function unescape(code) {
+		return code.replace(/\\('|\\)/g, "$1").replace( /[\r\t\n]/g, " ");
 	}
 
 	doT.template = function(tmpl, c, def, surl) {
@@ -100,27 +99,28 @@
 					.replace(/\r|\n|\t|\/\*[\s\S]*?\*\//g,""): str)
 			.replace(/'|\\/g, "\\$&")
 			.replace(c.interpolate || skip, function(m, code) {
-				return cse.start + unescape(code, c.minify) + cse.end;
+				return cse.start + unescape(code) + cse.end;
 			})
 			.replace(c.encode || skip, function(m, code) {
 				needhtmlencode = true;
-				return cse.startencode + unescape(code, c.minify) + cse.end;
+				return cse.startencode + unescape(code) + cse.end;
 			})
 			.replace(c.conditional || skip, function(m, elsecase, code) {
 				return elsecase ?
-					(code ? "';}else if(" + unescape(code, c.minify) + "){out+='" : "';}else{out+='") :
-					(code ? "';if(" + unescape(code, c.minify) + "){out+='" : "';}out+='");
+					(code ? "';}else if(" + unescape(code) + "){out+='" : "';}else{out+='") :
+					(code ? "';if(" + unescape(code) + "){out+='" : "';}out+='");
 			})
 			.replace(c.iterate || skip, function(m, iterate, vname, iname) {
 				if (!iterate) return "';} } out+='";
-				sid+=1; indv=iname || "i"+sid; iterate=unescape(iterate, c.minify);
+				sid+=1; indv=iname || "i"+sid; iterate=unescape(iterate);
 				return "';var arr"+sid+"="+iterate+";if(arr"+sid+"){var "+vname+","+indv+"=-1,l"+sid+"=arr"+sid+".length-1;while("+indv+"<l"+sid+"){"
 					+vname+"=arr"+sid+"["+indv+"+=1];out+='";
 			})
 			.replace(c.evaluate || skip, function(m, code) {
-				return "';" + unescape(code, c.minify) + "out+='";
+				return "';" + unescape(code) + "out+='";
 			})
 			+ "';return out;" + surl)
+			.replace(/\n/g, "\\n").replace(/\t/g, '\\t').replace(/\r/g, "\\r")
 			.replace(/(\s|;|\}|^|\{)out\+='';/g, '$1').replace(/\+''/g, "");
 			//.replace(/(\s|;|\}|^|\{)out\+=''\+/g,'$1out+=');
 

--- a/doT.js
+++ b/doT.js
@@ -90,8 +90,9 @@
 		return code.replace(/\\('|\\)/g, "$1").replace( minify || skip, " ");
 	}
 
-	doT.template = function(tmpl, c, def) {
+	doT.template = function(tmpl, c, def, surl) {
 		c = c || doT.templateSettings;
+		surl = surl ? '//# sourceURL=' + surl : '';
 		var cse = c.append ? startend.append : startend.split, needhtmlencode, sid = 0, indv,
 			str  = (c.use || c.define) ? resolveDefs(c, tmpl, def || {}) : tmpl;
 
@@ -119,7 +120,7 @@
 			.replace(c.evaluate || skip, function(m, code) {
 				return "';" + unescape(code, c.minify) + "out+='";
 			})
-			+ "';return out;")
+			+ "';return out;" + surl)
 			.replace(/\n/g, "\\n").replace(/\t/g, '\\t').replace(/\r/g, "\\r")
 			.replace(/(\s|;|\}|^|\{)out\+='';/g, '$1').replace(/\+''/g, "");
 			//.replace(/(\s|;|\}|^|\{)out\+=''\+/g,'$1out+=');
@@ -139,7 +140,7 @@
 		}
 	};
 
-	doT.compile = function(tmpl, def) {
-		return doT.template(tmpl, null, def);
+	doT.compile = function(tmpl, def, surl) {
+		return doT.template(tmpl, null, def, surl);
 	};
 }());

--- a/doT.js
+++ b/doT.js
@@ -118,7 +118,7 @@
 			.replace(c.iterate || skip, function(m, iterate, vname, iname) {
 				if (!iterate) return "';} } out+='";
 				sid+=1; indv=iname || "i"+sid; iterate=unescape(iterate);
-				return "';var arr"+sid+"="+iterate+";if(arr"+sid+"){var "+vname+","+indv+"=-1,l"+sid+"=arr"+sid+".length-1;while("+indv+"<l"+sid+"){"
+				return "';let arr"+sid+"="+iterate+";if(arr"+sid+"){let "+vname+","+indv+"=-1,l"+sid+"=arr"+sid+".length-1;while("+indv+"<l"+sid+"){"
 					+vname+"=arr"+sid+"["+indv+"+=1];out+='";
 			})
 			.replace(c.evaluate || skip, function(m, code) {


### PR DESCRIPTION
When working with complex templates on the browser, it is useful to be able to debug the templates.

This edit allows us to specify a sourceURL or sourceMappingURL as described here:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma