### PR TITLE
Allow iteration variable name to be empty, defaulting to the (first) varname

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -17,7 +17,7 @@
 			define:      /\{\{##\s*([\w\.$]+)\s*(\:|=)([\s\S]+?)#\}\}/g,
 			defineParams:/^\s*([\w$]+):([\s\S]+)/,
 			conditional: /\{\{\?(\?)?\s*([\s\S]*?)\s*\}\}/g,
-			iterate:     /\{\{~\s*(?:\}\}|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*\}\})/g,
+			iterate:     /\{\{~\s*(?:\}\}|([\s\S]+?)\s*(?:\:\s*([\w$]+))?\s*(?:\:\s*([\w$]+))?\s*\}\})/g,
 			varname:	"it",
 			strip:		true,
 			append:		true,
@@ -111,6 +111,7 @@
 			})
 			.replace(c.iterate || skip, function(m, iterate, vname, iname) {
 				if (!iterate) return "';} } out+='";
+				vname = vname || c.varname.split(',')[0];
 				sid+=1; indv=iname || "i"+sid; iterate=unescape(iterate);
 				return "';var arr"+sid+"="+iterate+";if(arr"+sid+"){var "+vname+","+indv+"=-1,l"+sid+"=arr"+sid+".length-1;while("+indv+"<l"+sid+"){"
 					+vname+"=arr"+sid+"["+indv+"+=1];out+='";

--- a/test/iteration.test.js
+++ b/test/iteration.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var test = require('./util').test;
+var doT = require('../doT');
 
 describe('iteration', function() {
     describe('without index', function() {
@@ -15,6 +16,25 @@ describe('iteration', function() {
 
         it('should concatenate items', function() {
             test(['{{~it.arr:x}}{{=x}}{{~}}'], {arr: [1,2,3]}, '123');
+        });
+    });
+
+    describe('without name', function () {
+        it('should concatenate items', function () {
+            test(['{{~it.arr}}{{=it}}{{~}}'], { arr: [1, 2, 3] }, '123');
+        });
+    });
+    
+    describe('without name and different varname', function() {
+        var originalVarName = doT.templateSettings.varname;
+        beforeEach(function() {
+            doT.templateSettings.varname = 'y, moo';
+        });
+        afterEach(function() {
+            doT.templateSettings.varname = originalVarName;
+        });
+        it('should concatenate items if varname has multiple names', function () {
+            test(['{{~y.arr}}{{=y}}{{~}}'], { arr: [1, 2, 3] }, '123');
         });
     });
 


### PR DESCRIPTION
This PR allows the variable name in iterations to be empty, as is already the case with the iterator name.

The name now defaults to the name defined in settings, which defaults to "it". In case multiple names where defined, it defaults to the first one. This allows for more concise templates:

    {{~it.array}}
    <div>{{=it}}!</div>
    {{~}}