### PR TITLE
Add spreadContext setting

### DIFF
--- a/doT.js
+++ b/doT.js
@@ -22,7 +22,8 @@
 			strip:		true,
 			append:		true,
 			selfcontained: false,
-			doNotSkipEncoded: false
+			doNotSkipEncoded: false,
+			spreadContext: false
 		},
 		template: undefined, //fn, compile template
 		compile:  undefined, //fn, for express
@@ -130,6 +131,21 @@
 				+ str;
 		}
 		try {
+			if (c.spreadContext) {
+				return function (context) {
+					var argnames = [];
+					var argvals = [];
+
+					for (var argname in context) {
+						argnames.push(argname);
+						argvals.push(context[argname]);
+					}
+
+					var f = Function.apply(this, argnames.concat([str]));
+
+					return f.apply(this, argvals);
+				};
+			}
 			return new Function(c.varname, str);
 		} catch (e) {
 			/* istanbul ignore else */

--- a/test/dot.test.js
+++ b/test/dot.test.js
@@ -14,7 +14,7 @@ describe('doT', function(){
 			assert.strictEqual(doT.name, 'doT');
 		});
 	});
-	
+
 	describe('#template()', function(){
 		it('should return a function', function(){
 			assert.equal(typeof basiccompiled, "function");
@@ -26,6 +26,26 @@ describe('doT', function(){
 			assert.equal(basiccompiled({foo:"http"}), "<div>http</div>");
 			assert.equal(basiccompiled({foo:"http://abc.com"}), "<div>http:&#47;&#47;abc.com</div>");
 			assert.equal(basiccompiled({}), "<div></div>");
+		});
+	});
+
+	describe('without scoping input to `varname`', function(){
+		var contextlesstemplate, contextlesscompiled
+
+		before(function(){
+			doT.templateSettings.spreadContext = true;
+			contextlesstemplate = "<div>{{!foo}}</div>";
+			contextlesscompiled = doT.template(contextlesstemplate);
+		});
+
+		after(function(){
+			doT.templateSettings.spreadContext = false;
+		});
+
+		it('should render the template without scoping input', function(){
+			assert.equal(contextlesscompiled({foo:"http"}), "<div>http</div>");
+			assert.equal(contextlesscompiled({foo:"http://abc.com"}), "<div>http:&#47;&#47;abc.com</div>");
+			assert.equal(contextlesscompiled({foo:null}), "<div></div>");
 		});
 	});
 


### PR DESCRIPTION
For lack of a better setting name...

This allows referencing the context in a template without it being scoped to the `varname` object.

e.g.
```javascript
dot.template('<div>Hello {{= friends }}</div>')
// instead of
dot.template('<div>Hello {{= it.friends }}</div>')
```

Full example:
```javascript
dot.templateSettings.spreadContext = true
const tempFn = dot.template('<div>Hello {{= friends }}</div>')
tempFn({ friends })
```