### PR TITLE
Bugfix/render falsy values when encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ http://olado.github.com/doT (todo: update docs with new features added in versio
 
 ### New in version 2.0.0
 
-#### `{{! }}` renders falsy values – except `undefined`
+#### `{{! }}` renders falsy values with the exception of `undefined`
 
-**Breaking change.** Falsy values – with the exception of `undefined` (i.e. `0`, `false`, `null`, `NaN` and an empty string) – are stringified to their string values. For example, `<p>{{! NaN }}</p>` is now rendered as `<p>NaN</p>`.
+**Breaking change.** The falsy values `0`, `false`, `null`, `NaN` and an empty string, but not `undefined` are stringified to their string values. For example, `<p>{{! NaN }}</p>` is now rendered as `<p>NaN</p>`. However, `<p>{{! undefined }}</p>` is still rendered as `<p></p>`.
 
-In previous versions, an empty string was returned for falsy values.
+In previous versions, an empty string was returned for any falsy value.
 
 If you need `{{! value }}` to produce an empty string where `value` is falsy, write `{{! value || '' }}` or `{{! value || undefined }}`. 
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,19 @@ doT.js is fast, small and has no dependencies.
 
 http://olado.github.com/doT (todo: update docs with new features added in version 1.0.0)
 
-## New in version 1.0.0
+## Changelog 
+
+### New in version 2.0.0
+
+#### `{{! }}` renders falsy values – except `undefined`
+
+**Breaking change.** Falsy values – with the exception of `undefined` (i.e. `0`, `false`, `null`, `NaN` and an empty string) – are stringified to their string values. For example, `<p>{{! NaN }}</p>` is now rendered as `<p>NaN</p>`.
+
+In previous versions, an empty string was returned for falsy values.
+
+If you need `{{! value }}` to produce an empty string where `value` is falsy, write `{{! value || '' }}` or `{{! value || undefined }}`. 
+
+### New in version 1.0.0
 
 ####Added parameters support in partials
 

--- a/doT.js
+++ b/doT.js
@@ -33,7 +33,7 @@
 		var encodeHTMLRules = { "&": "&#38;", "<": "&#60;", ">": "&#62;", '"': "&#34;", "'": "&#39;", "/": "&#47;" },
 			matchHTML = doNotSkipEncoded ? /[&<>"'\/]/g : /&(?!#?\w+;)|<|>|"|'|\//g;
 		return function(code) {
-			return code ? code.toString().replace(matchHTML, function(m) {return encodeHTMLRules[m] || m;}) : "";
+			return (typeof code === "undefined" ? "" : "" + code).replace(matchHTML, function(m) {return encodeHTMLRules[m] || m;});
 		};
 	};
 

--- a/test/dot.test.js
+++ b/test/dot.test.js
@@ -14,7 +14,7 @@ describe('doT', function(){
 			assert.strictEqual(doT.name, 'doT');
 		});
 	});
-	
+
 	describe('#template()', function(){
 		it('should return a function', function(){
 			assert.equal(typeof basiccompiled, "function");
@@ -30,13 +30,35 @@ describe('doT', function(){
 	});
 
 	describe('encoding of falsy values', function(){
-		it('should render undefined to an empty string, and the other falsy values to their string values', function(){
-			assert.equal(basiccompiled({foo:''}), "<div></div>");
-			assert.equal(basiccompiled({foo:undefined}), "<div></div>");
-			assert.equal(basiccompiled({foo:null}), "<div>null</div>");
-			assert.equal(basiccompiled({foo:false}), "<div>false</div>");
-			assert.equal(basiccompiled({foo:NaN}), "<div>NaN</div>");
-			assert.equal(basiccompiled({foo:0}), "<div>0</div>");
+		it('should render undefined to an empty string, and the other falsy values to their string values', function () {
+			assert.equal(basiccompiled({foo: ''}), "<div></div>");
+			assert.equal(basiccompiled({foo: undefined}), "<div></div>");
+			assert.equal(basiccompiled({foo: null}), "<div>null</div>");
+			assert.equal(basiccompiled({foo: false}), "<div>false</div>");
+			assert.equal(basiccompiled({foo: NaN}), "<div>NaN</div>");
+			assert.equal(basiccompiled({foo: 0}), "<div>0</div>");
+		});
+
+		it('should render an empty string when OR-ed with undefined', function () {
+			basictemplate = "<div>{{!it.foo || undefined}}</div>";
+			basiccompiled = doT.template(basictemplate);
+			assert.equal(basiccompiled({foo: ''}), "<div></div>");
+			assert.equal(basiccompiled({foo: undefined}), "<div></div>");
+			assert.equal(basiccompiled({foo: null}), "<div></div>");
+			assert.equal(basiccompiled({foo: false}), "<div></div>");
+			assert.equal(basiccompiled({foo: NaN}), "<div></div>");
+			assert.equal(basiccompiled({foo: 0}), "<div></div>");
+		});
+
+		it('should render an empty string when OR-ed with an empty string', function () {
+			basictemplate = "<div>{{!it.foo || ''}}</div>";
+			basiccompiled = doT.template(basictemplate);
+			assert.equal(basiccompiled({foo: ''}), "<div></div>");
+			assert.equal(basiccompiled({foo: undefined}), "<div></div>");
+			assert.equal(basiccompiled({foo: null}), "<div></div>");
+			assert.equal(basiccompiled({foo: false}), "<div></div>");
+			assert.equal(basiccompiled({foo: NaN}), "<div></div>");
+			assert.equal(basiccompiled({foo: 0}), "<div></div>");
 		});
 	});
 

--- a/test/dot.test.js
+++ b/test/dot.test.js
@@ -29,6 +29,17 @@ describe('doT', function(){
 		});
 	});
 
+	describe('encoding of falsy values', function(){
+		it('should render undefined to an empty string, and the other falsy values to their string values', function(){
+			assert.equal(basiccompiled({foo:''}), "<div></div>");
+			assert.equal(basiccompiled({foo:undefined}), "<div></div>");
+			assert.equal(basiccompiled({foo:null}), "<div>null</div>");
+			assert.equal(basiccompiled({foo:false}), "<div>false</div>");
+			assert.equal(basiccompiled({foo:NaN}), "<div>NaN</div>");
+			assert.equal(basiccompiled({foo:0}), "<div>0</div>");
+		});
+	});
+
 	describe('encoding with doNotSkipEncoded=false', function() {
 		it('should not replace &', function() {
 			global._encodeHTML = undefined;


### PR DESCRIPTION
* Changed the behavior of `{{! value }}` where value is falsy. `0`, `null`, `NaN`, `false` return their string values, `undefined` remains to return an empty string.
* Wrote tests to cover the new behavior.
* Updated the documentation to mention this as breaking change.

Fixes #274, #170, #178, #183.
