### PR TITLE
chore: reduce npm package install size

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,14 @@
   "bin": {
     "dottojs": "./bin/dot-packer"
   },
+  "files": [
+    "bin",
+    "index.js",
+    "doT.js",
+    "doT.min.js",
+    "README.md",
+    "LICENSE-DOT.txt"
+  ],
   "homepage": "http://github.com/olado/doT",
   "repository": "git://github.com/olado/doT.git",
   "author": "Laura Doktorova <ldoktorova@gmail.com>",


### PR DESCRIPTION
Add necessary `files` to package.json, this could reduce the npm install package size half.


